### PR TITLE
Create aggregate module

### DIFF
--- a/src/aggregate.py
+++ b/src/aggregate.py
@@ -1,9 +1,7 @@
 from argparse import ArgumentParser
 from typing import Type, Mapping, Dict
-import pickle
-import os
 
-from src.misc.settings import DataDir, DefaultFile
+from src.misc.utils import load_entity_maps_pkl
 from src.aggregations.aggregation import Aggregation
 from src.aggregations.primitive_pairs import PrimitivePairComparisonAggregation
 
@@ -40,13 +38,6 @@ def get_parser() -> ArgumentParser:
         help=("If present, any caches that the aggregation uses will be refreshed."),
     )
     return parser
-
-
-def load_entity_maps_pkl() -> Dict[str, dict]:
-    read_path = os.path.join(DataDir.EXTRACTION.value, DefaultFile.EXTRACTION_PKL.value)
-    print(f"Now loading pickled entity maps from '{read_path}'...")
-    with open(read_path, "rb") as f:
-        return pickle.load(f)
 
 
 if __name__ == "__main__":

--- a/src/aggregate.py
+++ b/src/aggregate.py
@@ -1,0 +1,59 @@
+from argparse import ArgumentParser
+from typing import Type, Mapping, Dict
+import pickle
+import os
+
+from src.misc.settings import DataDir, DefaultFile
+from src.aggregations.aggregation import Aggregation
+from src.aggregations.primitive_pairs import PrimitivePairComparisonAggregation
+
+
+aggregation_map: Mapping[str, Type[Aggregation]] = {
+    "primitive_pairs": PrimitivePairComparisonAggregation
+}
+
+def get_parser() -> ArgumentParser:
+    """
+    Configures the argument parser for aggregating a pickled extraction of pipeline runs.
+    """
+    parser = ArgumentParser(
+        description="Load and aggregate a pickled extraction of pipeline runs"
+    )
+    parser.add_argument(
+        "aggregation",
+        choices=aggregation_map.keys(),
+        help="The name of the aggregation to conduct"
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help=(
+            "If present, the aggregation will output detailed information on its "
+            "progress and intermediate results during computation, if applicable"
+        ),
+    )
+    parser.add_argument(
+        "--refresh",
+        "-r",
+        action="store_true",
+        help=("If present, any caches that the aggregation uses will be refreshed."),
+    )
+    return parser
+
+
+def load_entity_maps_pkl() -> Dict[str, dict]:
+    read_path = os.path.join(DataDir.EXTRACTION.value, DefaultFile.EXTRACTION_PKL.value)
+    print(f"Now loading pickled entity maps from '{read_path}'...")
+    with open(read_path, "rb") as f:
+        return pickle.load(f)
+
+
+if __name__ == "__main__":
+    parser = get_parser()
+    args = parser.parse_args()
+    entity_maps = load_entity_maps_pkl()
+    aggregation_class: Type[Aggregation] = aggregation_map[args.aggregation]
+    aggregation = aggregation_class()
+    print(f"Now running aggregation...")
+    aggregation.run(entity_maps, args.verbose, args.refresh)

--- a/src/aggregations/__init__.py
+++ b/src/aggregations/__init__.py
@@ -1,0 +1,4 @@
+"""
+Utilities for computing aggregate statistics on pipeline
+runs.
+"""

--- a/src/aggregations/aggregation.py
+++ b/src/aggregations/aggregation.py
@@ -1,0 +1,67 @@
+import csv, uuid, os
+from abc import ABC, abstractmethod
+from typing import Dict, List, Union
+
+from src.misc.settings import DataDir
+
+class Aggregation(ABC):
+    """
+    An abstract class inherited by all aggregation statistics
+    that are run by the `src.aggregate` module.
+    """
+
+    @abstractmethod
+    def run(self, entity_maps: Dict[str, dict], verbose: bool, refresh: bool, save_table: bool):
+        """
+        Parameters
+        ----------
+        entity_maps
+            A dictionary mapping extraction names to extraction dictionaries.
+            Contains extraction dictionaries for pipeline runs, problems,
+            pipelines, and datasets.
+        verbose
+            If true, the aggregation will output detailed information on its
+            progress and intermediate results during computation, if applicable
+        refresh
+            If true, disable caching while running the aggregation
+        """
+        pass
+
+    def save_table(self, table_name: str, fields: List[str],
+        data: List[Dict[str, Union[str, int, float]]], key: str=None):
+        """
+        Saves calculated aggregate data as a table where it can be exported to
+        e.g. Tableau for manual exploration.
+
+        Parameters
+        ----------
+        table_name
+            The string to use for the table's name.
+        fields
+            Complete list of columns in the table.
+        data
+            List of dictionaries representing the table. Each row is a dictionary
+            whose keys are the column names of the table. It is not required that
+            all the field names found in `fields` are present in every dictionary.
+        key
+            A string present in the list `fields` to use as the table's primary
+            key. If the value of `key` is not found in `fields`, a UUID will be
+            generated for each row in the table and named with the value of `key`.
+            Default of None means to use the first value in `fields` as the key.
+        """
+        if key is None:
+            key = fields[0]
+
+        if key not in fields:
+            for i in data:
+                data[key] = str(uuid.uuid4())
+
+        csv_dir = os.path.join(DataDir.AGGREGATION.value, self.__class__.__name__, 'csv')
+        if not os.path.isdir(csv_dir):
+            os.makedirs(csv_dir)
+
+        csv_path = os.path.join(csv_dir, table_name+'.csv')
+        with open(csv_path, 'w+', newline='') as csv_file:
+            csv_writer = csv.DictWriter(csv_file, fields)
+            csv_writer.writeheader()
+            csv_writer.writerows(data)

--- a/src/aggregations/aggregation.py
+++ b/src/aggregations/aggregation.py
@@ -53,8 +53,8 @@ class Aggregation(ABC):
             key = fields[0]
 
         if key not in fields:
-            for i in data:
-                data[key] = str(uuid.uuid4())
+            for record in data:
+                record[key] = str(uuid.uuid4())
 
         csv_dir = os.path.join(DataDir.AGGREGATION.value, self.__class__.__name__, 'csv')
         if not os.path.isdir(csv_dir):

--- a/src/aggregations/aggregation.py
+++ b/src/aggregations/aggregation.py
@@ -24,6 +24,9 @@ class Aggregation(ABC):
             progress and intermediate results during computation, if applicable
         refresh
             If true, disable caching while running the aggregation
+        save_table
+            If true, the aggregation will save its results in a CSV file upon
+            completion
         """
         pass
 

--- a/src/aggregations/primitive_pairs.py
+++ b/src/aggregations/primitive_pairs.py
@@ -1,0 +1,237 @@
+import itertools, uuid
+from tqdm import tqdm
+from collections import defaultdict
+from math import factorial
+from typing import Any, Dict, List, Tuple, Set, NamedTuple
+
+from src.misc.metrics import MetricProblemType
+from src.misc.settings import PredsLoadStatus
+from src.misc.utils import with_cache
+from src.entities.pipeline_run import PipelineRun
+from src.aggregations.aggregation import Aggregation
+
+
+class ScoreDiff(NamedTuple):
+    metric: str
+    abs_score_diff: float
+
+
+class PipelineRunPairDiffEntry(NamedTuple):
+    run_a: PipelineRun
+    run_b: PipelineRun
+    output_difference: float
+    output_difference_metric: MetricProblemType
+    score_diffs: List[ScoreDiff]
+
+
+def primitive_ids_and_paths(pipeline_runs: Dict[str, PipelineRun]) -> Tuple[List[str], Dict[str, Set[str]]]:
+    """
+    Given a dictionary of pipeline runs, this function finds all unique primitive
+    IDs and maps them to every associated python path.
+
+    Returns
+    -------
+    primitive_ids : List[str]
+        A sorted list of the unique primitive ids found in `pipeline_runs`.
+    prim_id_to_paths : Dict[str, Set[str]]
+        A mapping of each primitive id to a set of all python paths
+        associated with that id, as observed in `pipeline_runs`.
+    """
+    prim_id_to_paths: Dict[str, Set[str]] = defaultdict(set)
+    for run in pipeline_runs.values():
+        for prim_step in run.pipeline.flattened_steps:
+            prim_id_to_paths[prim_step.id].add(prim_step.python_path)
+
+    primitive_ids = list(prim_id_to_paths.keys())
+    primitive_ids.sort()
+
+    return primitive_ids, prim_id_to_paths
+
+def num_combinations(iterable, r):
+    """
+    Returns the number of combinations `itertools.combinations(iterable, r)`
+    returns.
+    Source: https://docs.python.org/2/library/itertools.html#itertools.combinations
+    """
+    n = len(iterable)
+    return factorial(n) // factorial(r) // factorial(n - r)
+
+
+class PrimitivePairComparisonAggregation(Aggregation):
+
+    def run(self, entity_maps: Dict[str, dict], verbose: bool=False,
+            refresh: bool=True, save_table: bool=True):
+        """
+        Builds the primitive pair comparison map (PPCM), a map of each possible
+        unordered primitive pair to a list. Each pair's list contains all
+        the pipeline run pairs that are almost identical, save the two primitives
+        of the pair are swapped in a single position on the pipeline
+        runs. As an example, in simplified syntax, the value at key
+        PPCM[("randomforest", "gradientboosting")] might have a list that contains the
+        pipeline pair: [dataset_to_dataframe, imputer, randomforest,
+        construct_predictions], [dataset_to_dataframe, imputer, gradientboosting,
+        construct_predictions], since these pipeline runs are only 1 primitive off
+        from each other, and the two primitives they're off on is randomforest
+        and gradientboosting.
+
+        Returns
+        -------
+        ppcm : Dict[Tuple[str, str], List[PipelineRunPairDiffEntry]]
+            The primitive pair comparison map (PPCM)
+        prim_id_to_paths : Dict[str, Set[str]]
+            A mapping of each primitive id to a set of all python paths
+            associated with that id, as observed in `pipeline_runs`.
+        prim_ids : List[str]
+            A sorted list of the unique primitive ids found in `pipeline_runs`.
+
+        Output Tables
+        -------------
+        primitive_pairs
+            A simple table assigning an id to each pair of primitives. Referenced
+            by the `diffs` table.
+        diffs
+            A table of the diffs between pipeline runs whose pipelines only
+            differ by one primitive step. References `primitive_pairs` table
+            (many-to-one). Referenced by `score_diffs` table.
+        score_diffs
+            A table recording by how much a pair of pipeline runs differ in a
+            specific metric. References the `diffs` table (many-to-one).
+        """
+
+        pipeline_runs = entity_maps['pipeline_runs']
+        prim_ids, prim_id_to_paths = primitive_ids_and_paths(pipeline_runs)
+
+        ppcm: Dict[Tuple[str, ...], List[PipelineRunPairDiffEntry]] = {
+            primitive_pair: []
+            for primitive_pair in itertools.combinations(prim_ids, 2)
+        }
+
+        # Filter out pipeline runs invalid for this analysis
+        valid_runs = [
+            run
+            for run in pipeline_runs.values()
+            # If the run wasn't successful there may not be any
+            # predictions for it; the run didn't complete.
+            if run.was_successful()
+            # We don't support calculating output differences for all
+            # problem types yet.
+            and run.problem.type in MetricProblemType.supported_types()
+            # We only calculate output differences on test set
+            # pipeline runs, since that measures the similarity
+            # of their generalization capacity.
+            and run.was_run_on_test_set()
+            and run.predictions_status != PredsLoadStatus.NOT_USEABLE
+        ]
+
+        # Fill the PPCM with values
+        for run_a, run_b in tqdm(
+            itertools.combinations(valid_runs, 2), total=num_combinations(valid_runs, 2)
+        ):
+
+            if run_a.is_same_problem_and_context_as(run_b) and run_a.is_one_step_off_from(
+                run_b
+            ):
+                # These two runs are one step off from each other and have
+                # all other attributes needed for this analysis.
+
+                run_a.load_predictions()
+                run_b.load_predictions()
+
+                # Get the primitive pair they are off by:
+                prim_pair = run_a.pipeline.get_steps_off_from(run_b.pipeline)[0]
+                prims_are_not_none = all(prim is not None for prim in prim_pair)
+                prim_a, prim_b = prim_pair
+
+                if (
+                    prims_are_not_none
+                    and prim_a.is_same_position_different_kind(prim_b)
+                    and run_a.predictions.same_dtype_as(run_b.predictions)
+                ):
+                    # The two pipelines are tantamount (including each primitive's inputs
+                    # and outputs), but with a single pair of primitives being different.
+                    prim_pair = tuple(sorted(prim.id for prim in prim_pair))
+                    output_difference, output_difference_metric = run_a.get_output_difference_from(
+                        run_b
+                    )
+                    run_diff = PipelineRunPairDiffEntry(
+                        run_a, run_b, output_difference, output_difference_metric, []
+                    )
+                    # Next get the differences between their scores
+                    for metric, scores in run_a.get_scores_of_common_metrics(run_b).items():
+                        run_a_score, run_b_score = scores
+                        score_diff = ScoreDiff(
+                            metric, abs(run_a_score.value - run_b_score.value)
+                        )
+                        run_diff.score_diffs.append(score_diff)
+                    # Add the run diff to the ppcm, mapped to the primitive pair
+                    # its off by.
+                    ppcm[prim_pair].append(run_diff)
+
+        if save_table:
+            print('Formatting data for writing to table...')
+
+            tables = {
+                'primitive_pairs': (
+                    ['pair_id', 'prim_a', 'python_path_a', 'prim_b', 'python_path_b'],
+                    [],
+                    None
+                ),
+                'diffs': (
+                    ['diff_id', 'run_a_id', 'run_b_id', 'output_diff',
+                        'output_diff_metric', 'pair_id'],
+                    [],
+                    None
+                ),
+                'score_diffs': (
+                    ['score_diff_id', 'metric', 'abs_score_diff', 'diff_id'],
+                    [],
+                    None
+                )
+            }
+
+            keys = list(ppcm.keys())
+            while len(keys) > 0:
+                prim_pair = keys.pop(0)
+                run_diff_list = ppcm.pop(prim_pair)
+                pair_uuid = str(uuid.uuid4())
+
+                tables['primitive_pairs'][1].append({
+                    'pair_id': pair_uuid,
+                    'prim_a': prim_pair[0],
+                    'python_path_a': prim_id_to_paths[prim_pair[0]],
+                    'prim_b': prim_pair[1],
+                    'python_path_b': prim_id_to_paths[prim_pair[1]]
+                })
+
+                while len(run_diff_list) > 0:
+                    run_diff = run_diff_list.pop(0)
+                    diff_uuid = str(uuid.uuid4())
+
+                    tables['diffs'][1].append({
+                        'diff_id': diff_uuid,
+                        'run_a_id': run_diff.run_a.get_id(),
+                        'run_b_id': run_diff.run_b.get_id(),
+                        'output_diff': run_diff.output_difference,
+                        'output_diff_metric': run_diff.output_difference_metric.name,
+                        'pair_id': pair_uuid
+                    })
+
+                    while len(run_diff.score_diffs) > 0:
+                        score_diff = run_diff.score_diffs.pop(0)
+                        score_diff_uuid = str(uuid.uuid4())
+
+                        tables['score_diffs'][1].append({
+                            'score_diff_id': score_diff_uuid,
+                            'metric': score_diff.metric,
+                            'abs_score_diff': score_diff.abs_score_diff,
+                            'diff_id': diff_uuid
+                        })
+
+            print('Finished formatting data. Records in each table:')
+            for table_name, params in tables.items():
+                print(f"{table_name}: "+str(len(params[1])))
+
+            for table_name, params in tables.items():
+                self.save_table(table_name, *params)
+
+        return {'ppcm':ppcm,'prim_id_to_paths':prim_id_to_paths,'prim_ids':prim_ids}

--- a/src/analyses/analysis.py
+++ b/src/analyses/analysis.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Callable
+from typing import Dict, Callable, Any
 
 import pprint
 
@@ -10,12 +10,23 @@ class Analysis(ABC):
     """
     All analyses that are run by the `src.analyze` module should inherit
     this abstract class, so they match the `src.analyze` module's API.
+
+    Attributes
+    ----------
+    required_aggregations
+        A list of the aggregations that must have been calculated for an
+        analysis to be performed. The output files from these aggregations
+        are ingested in the `src.analyze` module and passed to the analysis's
+        run method via the `aggregation_maps` parameter.
     """
 
     pp = pprint.PrettyPrinter(indent=2).pprint
 
+    required_aggregations = []
+
     @abstractmethod
-    def run(self, entity_maps: Dict[str, dict], verbose: bool, refresh: bool):
+    def run(self, entity_maps: Dict[str, dict], verbose: bool, refresh: bool,
+            aggregations: Dict[str, Any]=None):
         """
         Parameters
         ----------
@@ -31,5 +42,9 @@ class Analysis(ABC):
             pyplot pop-up windows will appear when `True`.
         refresh
             Whether to refresh any caches that this analysis uses.
+        aggregations
+            A dictionary mapping aggregation names to the data computed and
+            stored by that aggregation. This data can be in any format, varying
+            based on the needs of the specific aggregation.
         """
         pass

--- a/src/analyses/duplicate_primitives.py
+++ b/src/analyses/duplicate_primitives.py
@@ -9,141 +9,11 @@ from tqdm import tqdm
 import matplotlib.pyplot as plt
 
 from src.analyses.analysis import Analysis
+from src.aggregations.primitive_pairs import PrimitivePairComparisonAggregation, ScoreDiff, PipelineRunPairDiffEntry
 from src.entities.pipeline import Pipeline
 from src.entities.primitive import Primitive
 from src.entities.pipeline_run import PipelineRun
 from src.misc.utils import with_cache
-from src.misc.metrics import MetricProblemType
-from src.misc.settings import PredsLoadStatus
-
-
-class ScoreDiff(NamedTuple):
-    metric: str
-    abs_score_diff: float
-
-
-class PipelineRunPairDiffEntry(NamedTuple):
-    run_a: PipelineRun
-    run_b: PipelineRun
-    output_difference: float
-    output_difference_metric: MetricProblemType
-    score_diffs: List[ScoreDiff] = []
-
-
-def num_combinations(iterable, r):
-    """
-    Returns the number of combinations `itertools.combinations(iterable, r)`
-    returns.
-    Source: https://docs.python.org/2/library/itertools.html#itertools.combinations
-    """
-    n = len(iterable)
-    return fac(n) // fac(r) // fac(n - r)
-
-
-def build_ppcm(pipeline_runs: Dict[str, PipelineRun]):
-    """
-    Builds the primitive pair comparison map (PPCM), a map of each possible
-    unordered primitive pair to a list. Each pair's list contains all
-    the pipeline run pairs that are almost identical, save the two primitives
-    of the pair are swapped in a single position on the pipeline
-    runs. As an example, in simplified syntax, the value at key
-    PPCM[("randomforest", "gradientboosting")] might have a list that contains the
-    pipeline pair: [dataset_to_dataframe, imputer, randomforest,
-    construct_predictions], [dataset_to_dataframe, imputer, gradientboosting,
-    construct_predictions], since these pipeline runs are only 1 primitive off
-    from each other, and the two primitives they're off on is randomforest
-    and gradientboosting.
-
-    Returns
-    -------
-    ppcm : Dict[Tuple[str, str], List[PipelineRunPairDiffEntry]]
-        The primitive pair comparison map (PPCM)
-    prim_id_to_paths : Dict[str, Set[str]]
-        A mapping of each primitive id to a set of all python paths
-        associated with that id, as observed in `pipeline_runs`.
-    primitive_ids : List[str]
-        A sorted list of the unique primitive ids found in `pipeline_runs`. 
-    """
-
-    # Get the ids and their corresponding python paths of all
-    # primitives used in the pipeline runs
-
-    prim_id_to_paths: Dict[str, Set[str]] = defaultdict(set)
-    for run in pipeline_runs.values():
-        for prim_step in run.pipeline.flattened_steps:
-            prim_id_to_paths[prim_step.id].add(prim_step.python_path)
-
-    # Initialize the empty PPCM
-
-    primitive_ids = list(prim_id_to_paths.keys())
-    primitive_ids.sort()
-
-    ppcm: Dict[Tuple[str, ...], List[PipelineRunPairDiffEntry]] = {
-        primitive_pair: []
-        for primitive_pair in itertools.combinations(primitive_ids, 2)
-    }
-
-    # Filter out pipeline runs invalid for this analysis
-    valid_runs = [
-        run
-        for run in pipeline_runs.values()
-        # If the run wasn't successful there may not be any
-        # predictions for it; the run didn't complete.
-        if run.was_successful()
-        # We don't support calculating output differences for all
-        # problem types yet.
-        and run.problem.type in MetricProblemType.supported_types()
-        # We only calculate output differences on test set
-        # pipeline runs, since that measures the similarity
-        # of their generalization capacity.
-        and run.was_run_on_test_set()
-        and run.predictions_status != PredsLoadStatus.NOT_USEABLE
-    ]
-
-    # Fill the PPCM with values
-
-    for run_a, run_b in tqdm(
-        itertools.combinations(valid_runs, 2), total=num_combinations(valid_runs, 2)
-    ):
-        if run_a.is_same_problem_and_context_as(run_b) and run_a.is_one_step_off_from(
-            run_b
-        ):
-            # These two runs are one step off from each other and have
-            # all other attributes needed for this analysis.
-
-            run_a.load_predictions()
-            run_b.load_predictions()
-
-            # Get the primitive pair they are off by:
-            prim_pair = run_a.pipeline.get_steps_off_from(run_b.pipeline)[0]
-            prims_are_not_none = all(prim is not None for prim in prim_pair)
-            prim_a, prim_b = prim_pair
-
-            if (
-                prims_are_not_none
-                and prim_a.is_same_position_different_kind(prim_b)
-                and run_a.predictions.same_dtype_as(run_b.predictions)
-            ):
-                # The two pipelines are tantamount (including each primitive's inputs
-                # and outputs), but with a single pair of primitives being different.
-                prim_pair = tuple(sorted(prim.id for prim in prim_pair))
-                output_difference, output_difference_metric = run_a.get_output_difference_from(
-                    run_b
-                )
-                run_diff = PipelineRunPairDiffEntry(
-                    run_a, run_b, output_difference, output_difference_metric
-                )
-                # Next get the differences between their scores
-                for metric, scores in run_a.get_scores_of_common_metrics(run_b).items():
-                    run_a_score, run_b_score = scores
-                    score_diff = ScoreDiff(
-                        metric, abs(run_a_score.value - run_b_score.value)
-                    )
-                    run_diff.score_diffs.append(score_diff)
-                # Add the run diff to the ppcm, mapped to the primitive pair
-                # its off by.
-                ppcm[prim_pair].append(run_diff)
-    return ppcm, prim_id_to_paths, primitive_ids
 
 
 class DuplicatePrimitivesAnalysis(Analysis):
@@ -153,17 +23,24 @@ class DuplicatePrimitivesAnalysis(Analysis):
     the exact same results when used interchangeably?
     """
 
-    def run(self, entity_maps: Dict[str, dict], verbose: bool, refresh: bool):
+    required_aggregations = [PrimitivePairComparisonAggregation]
+
+    def run(self, entity_maps: Dict[str, dict], verbose: bool, refresh: bool,
+            aggregations: Dict[str, Any]=None):
 
         # config
         num_top_pairs_to_show = 10
 
         pipeline_runs = entity_maps["pipeline_runs"]
-        ppcm, prim_id_to_paths, primitive_ids = with_cache(build_ppcm, refresh)(
-            pipeline_runs
-        )
+        prim_id_to_paths = aggregations['PrimitivePairComparisonAggregation']['prim_id_to_paths']
+        primitive_ids = aggregations['PrimitivePairComparisonAggregation']['prim_ids']
+
         # A list version of the PPCM
-        ppcl: Any = [(prim_pair, diff_list) for prim_pair, diff_list in ppcm.items()]
+        ppcl: Any = [
+            (prim_pair, diff_list)
+            for prim_pair, diff_list
+            in aggregations['PrimitivePairComparisonAggregation']['ppcm'].items()
+        ]
         ppcl.sort(key=lambda entry: len(entry[1]), reverse=True)
 
         # Get the distribution of entries in the PPCM.
@@ -203,15 +80,6 @@ class DuplicatePrimitivesAnalysis(Analysis):
                     "count": num_output_diffs,
                 }
 
-            avg_metric_diff = (
-                sum(
-                    score_diff.abs_score_diff
-                    for diff in diff_list
-                    for score_diff in diff.score_diffs
-                )
-                / num_diffs
-            )
-
             avg_output_diff = (
                 sum(diff.output_difference for diff in diff_list) / num_diffs
             )
@@ -221,10 +89,9 @@ class DuplicatePrimitivesAnalysis(Analysis):
                     "prim_a_paths": prim_id_to_paths[prim_id_a],
                     "prim_b_paths": prim_id_to_paths[prim_id_b],
                     "num_diffs": num_diffs,
-                    "avg_metric_diff": avg_metric_diff,
                     "avg_score_diffs_by_metric": avg_score_diffs_by_metric,
                     "avg_output_diff": avg_output_diff,
-                    "avg_ouptut_diffs_by_metric": avg_output_diffs_by_metric,
+                    "avg_output_diffs_by_metric": avg_output_diffs_by_metric,
                 }
             )
 

--- a/src/analyze.py
+++ b/src/analyze.py
@@ -1,5 +1,5 @@
 from argparse import ArgumentParser
-from typing import Type, Mapping, Dict
+from typing import Type, Mapping, Dict, List, Any
 import pickle
 import os
 
@@ -56,11 +56,28 @@ def load_entity_maps_pkl() -> Dict[str, dict]:
         return pickle.load(f)
 
 
+def load_aggregations(req_aggs: List[str]) -> Dict[str, Any]:
+    aggs = {}
+    if len(req_aggs) == 0:
+        return aggs
+
+    for agg_class in req_aggs:
+        agg_name = agg_class.__name__
+        agg = agg_class()
+        print(f'Running aggregation {agg_name}...')
+        aggs[agg_name] = agg.run(entity_maps=entity_maps, save_table=False)
+
+    return aggs
+
+
 if __name__ == "__main__":
     parser = get_parser()
     args = parser.parse_args()
     entity_maps = load_entity_maps_pkl()
+    aggregations = load_aggregations(analysis.required_aggregations)
+
     analysis_class: Type[Analysis] = analysis_map[args.analysis]
     analysis = analysis_class()
+
     print(f"Now running {args.analysis} analysis...")
-    analysis.run(entity_maps, args.verbose, args.refresh)
+    analysis.run(entity_maps=entity_maps, aggregations=aggregations, verbose=args.verbose, refresh=args.refresh)

--- a/src/analyze.py
+++ b/src/analyze.py
@@ -1,9 +1,7 @@
 from argparse import ArgumentParser
 from typing import Type, Mapping, Dict, List, Any
-import pickle
-import os
 
-from src.misc.settings import DataDir, DefaultFile
+from src.misc.utils import load_entity_maps_pkl
 from src.analyses.analysis import Analysis
 from src.analyses.basic_stats import BasicStatsAnalysis
 from src.analyses.duplicate_pipelines import DuplicatePipelinesAnalysis
@@ -49,13 +47,6 @@ def get_parser() -> ArgumentParser:
     return parser
 
 
-def load_entity_maps_pkl() -> Dict[str, dict]:
-    read_path = os.path.join(DataDir.EXTRACTION.value, DefaultFile.EXTRACTION_PKL.value)
-    print(f"Now loading pickled entity maps from '{read_path}'...")
-    with open(read_path, "rb") as f:
-        return pickle.load(f)
-
-
 def load_aggregations(req_aggs: List[str]) -> Dict[str, Any]:
     aggs = {}
     if len(req_aggs) == 0:
@@ -74,10 +65,9 @@ if __name__ == "__main__":
     parser = get_parser()
     args = parser.parse_args()
     entity_maps = load_entity_maps_pkl()
-    aggregations = load_aggregations(analysis.required_aggregations)
-
     analysis_class: Type[Analysis] = analysis_map[args.analysis]
     analysis = analysis_class()
+    aggregations = load_aggregations(analysis.required_aggregations)
 
     print(f"Now running {args.analysis} analysis...")
     analysis.run(entity_maps=entity_maps, aggregations=aggregations, verbose=args.verbose, refresh=args.refresh)

--- a/src/misc/settings.py
+++ b/src/misc/settings.py
@@ -22,6 +22,7 @@ class DataDir(Enum):
     INDEXES_DUMP = os.path.join(DATA_ROOT, "dump/indexes")
     PREDICTIONS_DUMP = os.path.join(DATA_ROOT, "dump/predictions")
     EXTRACTION = os.path.join(DATA_ROOT, "extractions")
+    AGGREGATION = os.path.join(DATA_ROOT, "aggregations")
     CACHE = os.path.join(DATA_ROOT, "cached-function-calls")
 
 

--- a/src/misc/utils.py
+++ b/src/misc/utils.py
@@ -4,7 +4,7 @@ import os
 import json
 import glob
 
-from src.misc.settings import DataDir
+from src.misc.settings import DataDir, DefaultFile
 
 
 def has_path(dictionary: dict, keys: list) -> bool:
@@ -103,6 +103,13 @@ def with_cache(f: Callable, refresh=False) -> Callable:
             return result
 
     return f_with_cache
+
+
+def load_entity_maps_pkl() -> Dict[str, dict]:
+    read_path = os.path.join(DataDir.EXTRACTION.value, DefaultFile.EXTRACTION_PKL.value)
+    print(f"Now loading pickled entity maps from '{read_path}'...")
+    with open(read_path, "rb") as f:
+        return pickle.load(f)
 
 
 def process_json(path: str, processor: Callable, *args, **kwargs) -> Any:


### PR DESCRIPTION
Addresses #5. This PR creates the aggregate module and moves the primitive pair comparison logic from the `duplicate_primitives` analysis to its own `primitive_pairs` aggregation.

At the moment the aggregations only output CSV files of their results and don't persist data for the analyses that depend on them. Instead, an analysis that depends on an aggregation will run the entire aggregation(s) before performing the analysis. Obviously we want to avoid this by having aggregations persist their results, but we're in the middle of considering more big-data-friendly alternatives to the `pickle` module, so the persistence will be implemented after a decision is made on that; this PR is just a start.